### PR TITLE
Add InstanceNorm and wide refactoring of TrainLib_Deployer's memory allocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ PULP-TrainLib is the first Deep Neural Network (DNN) training library for multi-
 PULP-TrainLib features a variety of training primitives and support functions to enable backpropagation-based training on multicore MCUs. More in depth:
 
 - A set of performance-tunable DNN layer primitives for training, based on Matrix Multiplication (MM). 
-- Several common loss functions, like MSE and CrossEntropy. 
+- Commonly used loss functions, like MSE and CrossEntropy. 
 - SGD-based optimizers.
 - Activation (ReLU, etc) and support functions.
 
@@ -37,18 +37,17 @@ pages="200--216",
 abstract="An open challenge in making Internet-of-Things sensor nodes ``smart'' and self-adaptive is to enable on-chip Deep Neural Network (DNN) training on Ultra-Low-Power (ULP) microcontroller units (MCUs). To this aim, we present a framework, based on PULP-TrainLib, to deploy DNN training tasks on RISC-V-based Parallel-ULP (PULP) MCUs. PULP-TrainLib is a library of parallel software DNN primitives enabling the execution of forward and backward steps on PULP MCUs. To optimize PULP-TrainLib's kernels, we propose a strategy to automatically select and configure (autotune) the fastest among a set of tiling options and optimized floating-point matrix multiplication kernels, according to the tensor shapes of every DNN layer. Results on an 8-core RISC-V MCU show that our auto-tuned primitives improve MAC/clk by up to 2.4{\$}{\$}{\backslash}times {\$}{\$}{\texttimes}compared to ``one-size-fits-all'' matrix multiplication, achieving up to 4.39 MAC/clk - 36.6{\$}{\$}{\backslash}times {\$}{\$}{\texttimes}better than a commercial STM32L4 MCU executing the same DNN layer training workload. Furthermore, our strategy proves to be 30.7{\$}{\$}{\backslash}times {\$}{\$}{\texttimes}faster than AIfES, a state-of-the-art training library for MCUs, while training a complete TinyML model.",
 isbn="978-3-031-15074-6"
 }
-
 ```
 
 This repository is released under the [Apache License Version 2.0](./LICENSE).
 
 ## PULP-TrainLib's training library
 
-PULP-TrainLib is the first open-source training library for RISC-V-based multicore MCUs, including a set of performance-tunable DNN layer primitives to enable DNN training on ultra-low-power devices. The training flow of PULP-TrainLib's primitives follows the canonic approach for the backpropagation algorithm, considering a streaming approach (batch size = 1). I.e., first we compute the Forward (FW) step to compute the prediction for a given input data. Then, a Backward Step is called to compute, layer-by-layer, the gradient of the loss function with respect to the weights (WG-BW) and the gradient of the loss function with respect to the input (IG-BW). The structure of the training flow of a single layer (e.g. a Fully-Connected) is depicted as follows:
+PULP-TrainLib is the first open-source training library for RISC-V-based multicore MCUs, including a set of performance-tunable DNN layer primitives to enable DNN training on ultra-low-power devices. The training flow of PULP-TrainLib's primitives follows the canonic approach for the backpropagation algorithm, currently considering a streaming approach (batch size = 1). I.e., first we compute the Forward (FW) step to compute the prediction for a given input data. Then, a Backward Step is called to compute, layer-by-layer, the gradient of the loss function with respect to the weights (WG-BW) and the gradient of the loss function with respect to the input (IG-BW). The structure of the training flow of a single layer (e.g. a Fully-Connected) is depicted as follows:
 
 ![PULP-TrainLib's Primitives](./assets/img/pulp-trainlib-primitives.png)
 
-Note that every training step for most of the layers are implemented as a Matrix Multiplication (MM) between tensor data. E.g., for a Conv2D and Fully-Connected Layer, the structure and sizes of the involved matrices can be represented as follows:
+Note that every training step for most of the layers is implemented as a Matrix Multiplication (MM) between tensor data. E.g., for a Conv2D and Fully-Connected Layer, the structure and sizes of the involved matrices can be represented as follows:
 
 ![MM-based training primitives](./assets/img/pulp-trainlib-mm-flow.png)
 
@@ -57,11 +56,11 @@ Convolutions are implemented as Image-to-Column (or Image-to-Row) pre-processed 
 
 ## The TrainLib_Deployer
 
-The development of C code for running On-Device Learning can be a time-consuming process. To make deployment easier, PULP-TrainLib provides TrainLib_Deployer, a code generation tool which creates all the necessary files to run DNN validation and training on PULP. To minimize the memory occupation, the TrainLib_Deployer adopts a data-reuse approach to store tensors in C arrays. The flow of the TrainLib_Deployer is illustrated as follows:
+The development of C code for running On-Device Learning can be a time-consuming process. To make deployment easier, PULP-TrainLib provides TrainLib_Deployer, a code generation tool which creates all the necessary files to run DNN validation and training on a [PULP](https://pulp-platform.org/)-based MCU. To minimize the memory occupation, the TrainLib_Deployer adopts a data-reuse approach to store tensors in C arrays. The flow of the TrainLib_Deployer is illustrated as follows:
 
 ![TrainLib_Deployer](./assets/img/trainlib-deployer.png)
 
-The input arguments of the TrainLib_Deployer are the architecture of the model to be trained on an MCU and the setup (memory and number of cores) of the target device. While running, the tool takes care of verifying if the model fits the memory. As output, the tool generates a project folder containing all the code to run a verification task on the target model (PyTorch Golden Model, or GM, C code, Makefile). 
+The input arguments of the TrainLib_Deployer are the architecture of the model to be trained on an MCU and the setup (memory and number of cores) of the target device. Indeed, the tool assumes to run an On-Device Learning routine on an MCU equipped with N parallel cores for computation. While running, the tool takes care of verifying if the model fits the memory. As output, the tool generates a project folder containing the code to run a verification task of the target DNN model on the target device (PyTorch Golden Model, or GM, C code, Makefile). 
 
 
 ## PULP-TrainLib's AutoTuner
@@ -79,13 +78,13 @@ Given the properties of the target device and the layer/training step informatio
 
 PULP-TrainLib's library files are located under the `lib/` folder ([lib's README](lib/README.md)).
 
-The `tests/` folder provides useful tests to try out and verify PULP-TrainLib's layers and functions (tests are performed against PyTorch Golden models).
+The `tests/` folder provides useful tests to try out and verify PULP-TrainLib's layers and functions (tests are performed with respecto to a PyTorch Golden models).
 Each test can be customized according to the user specifications and profiles the execution of the layer's primitives with PULP's performance counters.
 If further info are needed, please refer to the [test's README](tests/README.md).
 
 The `tools/` folder contains useful tools which ease the usage of PULP-TrainLib, as the TrainLib_Deployer and AutoTuner. For further info, please refer to [tools' README](tools/README.md).
 
-The `assets/` folder contains useful support files for PULP-TrainLib. Inside [CI_test_suite](assets/CI_test_suite/), users can find a testing environment that can be used to verify PULP-TrainLib's primitives for Continuous Integration. 
+The `assets/` folder contains useful support files for PULP-TrainLib. Inside [CI_test_suite](assets/CI_test_suite/), users can find a testing environment that can be used to verify PULP-TrainLib's primitives for Continuous Integration (TO BE COMPLETED). 
 
 
 # Tutorials
@@ -111,7 +110,7 @@ python -m pip install install torch torchvision torchaudio --index-url https://d
 python -m pip install torchsummary
 ```
 
-If you require the GPU (CUDA 10.2) version for your applications, instead run:
+If you require the GPU (CUDA >= 10.2) version for your applications, instead run:
 
 ```
 python -m pip install argparse 
@@ -152,27 +151,25 @@ PULP-TrainLib's repository is organized with these branches:
 
 > Note: checked are complete, unchecked are ongoing
 
-- [X] Forward passes for DepthWise, PointWise and 2D Convolution, Fully-Connected (FP32, FP16)
-- [X] Weight gradients for DepthWise, PointWise and 2D Convolution, Fully-Connected (FP32, FP16)
-- [X] Input gradients for DepthWise and PointWise Convolution, Fully-Connected, Conv2D (FP32, FP16)
-- [X] CWH data layout for DepthWise, PointWise and 2D Convolutions (FP32, FP16) - no stride, padding
-- [X] HWC data layout for PointWise Convolution (FP32, FP16) and 2D Convolutions (FP32, FP16) - stride and padding only for naive 2D Convolutions (without im2col+mm)
-- [X] ReLU activation function (FP32, FP16)
-- [X] Sigmoid activation function (FP32, FP16)
+- [X] Forward passes for DepthWise, PointWise Convolutions and Conv2D, Fully-Connected (FP32, FP16)
+- [X] Weight gradients for DepthWise, PointWise Convolutions and Conv2D, Fully-Connected (FP32, FP16)
+- [X] Input gradients for DepthWise, PointWise Convolutions and Conv2D, Fully-Connected (FP32, FP16)
+- [X] CWH data layout for DepthWise, PointWise and 2D Convolutions (FP32, FP16)
+- [X] HWC data layout for PointWise Convolution (FP32, FP16) and 2D Convolutions (FP32, FP16)
+- [X] stride and padding (only naive 2D Convolutions, without im2col+mm optimization)
+- [X] ReLU, Sigmoid activation functions (FP32, FP16)
 - [X] Gradient Descent optimizer (FP32, FP16)
 - [X] Max and Average Pooling (FP32, FP16)
 - [X] RNN training primitives (FP32)
 - [X] Multihead Self Attention training primitives (FP32)
 - [X] Residual connection (FP32, FP16)
 - [X] InstanceNorm (FP32, FP16)
-- [X] Padding and stride operators for 2D Convolution (internally managed, only for naive formula)
 - [ ] Padding operators for DepthWise and 2D Convolution (im2col + mm)
 - [ ] HWC data layout management for DepthWise Convolution (FP32, FP16)
 - [ ] Stride operators for 2D Convolutions and DepthWise (im2col + mm)
 - [ ] RNN training primitives (FP16)
 - [ ] Multihead Self Attention training primitives (FP16)
 - [ ] Biases for all layers
-- [ ] Migration to graph-managed padding (TrainLib_Deployer)
 - [ ] Fix of TrainLib_Deployer to support new graph-level optimizations of layers
 - [ ] Sparse Update (layer-wise) in TrainLib_Deployer
 

--- a/tools/TrainLib_Deployer/deployer_utils/DNN_Composer.py
+++ b/tools/TrainLib_Deployer/deployer_utils/DNN_Composer.py
@@ -92,7 +92,7 @@ def DNN_Size_Checker (layers_l, in_ch_l, out_ch_l, hk_l, wk_l, hin_l, win_l, h_s
     # Buffer memory allocation for Single Buffer mode
     l1_buff_size = 0
     if USE_DMA == 'SB':
-        MAX_LAYER_DIM = utilsSB.max_layer_dim(layers_l, in_ch_l, hin_l, win_l, out_ch_l, hk_l, wk_l, data_type_l[0], h_str_list, w_str_list, h_pad_list, w_pad_list)
+        MAX_LAYER_DIM, MAX_LAYER_DIM_BYTES = utilsSB.max_layer_dim(layers_l, in_ch_l, hin_l, win_l, out_ch_l, hk_l, wk_l, data_type_l[0], h_str_list, w_str_list, h_pad_list, w_pad_list, data_type_l, update_layer_l)
         l1_buff_size = MAX_LAYER_DIM
         
         l1_structs_mem = 0
@@ -114,33 +114,39 @@ def DNN_Size_Checker (layers_l, in_ch_l, out_ch_l, hk_l, wk_l, hin_l, win_l, h_s
         total_memory_occupation_bytes += l1_buff_size + l1_structs_mem
 
         # Label storage memory
+        # Size of the last layer in bytes
+        nbytes_label = 4
+        if data_type_l[-1] == 'FP16':
+            nbytes_label = 2
         h_out_net = np.floor((hin_l[-1] - hk_l[-1] + h_str_list[-1] + 2*h_pad_list[-1]) / h_str_list[-1])
         w_out_net = np.floor((win_l[-1] - wk_l[-1] + w_str_list[-1] + 2*w_pad_list[-1]) / w_str_list[-1])
-        labels_mem = out_ch_l[-1] * h_out_net * w_out_net
+        labels_mem = out_ch_l[-1] * h_out_net * w_out_net * nbytes_label
         print(f"Size of allocated memory for labels (Single Buffer Mode): {labels_mem} bytes")
         total_memory_occupation_bytes += labels_mem
 
     elif USE_DMA == 'DB':
         
-        MAX_LAYER_DIM = utilsDB.max_layer_dim(layers_l, in_ch_l, hin_l, win_l, out_ch_l, hk_l, wk_l, data_type_l[0], h_str_list, w_str_list, h_pad_list, w_pad_list)
-        l1_buff_size = MAX_LAYER_DIM
+        # MAX_LAYER_DIM, MAX_LAYER_DIM_BYTES = utilsDB.max_layer_dim(layers_l, in_ch_l, hin_l, win_l, out_ch_l, hk_l, wk_l, data_type_l[0], h_str_list, w_str_list, h_pad_list, w_pad_list)
+        # l1_buff_size = MAX_LAYER_DIM
         
 
-        l1_structs_mem = 0
-        l1_structs_mem += 7*(6*4) # 4 blobs input_blob, output_blob ..
-        l1_structs_mem += 32 # linear_args
-        l1_structs_mem += 76 # conv2d_args
-        l1_structs_mem += 40 # PW_args
-        l1_structs_mem += 40 # DW_args
-        l1_structs_mem += 8 # act_args
-        l1_structs_mem += 16 # Skipconn_args
-        l1_structs_mem += 3*4 # 3 pi_cl_dma_cmd_t cmd_load, cmd_store and cmd_struct
-        l1_structs_mem += 2 # loss in fp16
-        if data_type_l[0] == 'FP32':
-            l1_structs_mem += 2 # loss in fp32
-        l1_structs_mem += 16 # vect_sum_args
-        print(f"Size of structures in L1 (Double Buffer Mode): {l1_structs_mem} bytes")
-        total_memory_occupation_bytes += l1_buff_size + l1_structs_mem
+        # l1_structs_mem = 0
+        # l1_structs_mem += 7*(6*4) # 4 blobs input_blob, output_blob ..
+        # l1_structs_mem += 32 # linear_args
+        # l1_structs_mem += 76 # conv2d_args
+        # l1_structs_mem += 40 # PW_args
+        # l1_structs_mem += 40 # DW_args
+        # l1_structs_mem += 8 # act_args
+        # l1_structs_mem += 16 # Skipconn_args
+        # l1_structs_mem += 3*4 # 3 pi_cl_dma_cmd_t cmd_load, cmd_store and cmd_struct
+        # l1_structs_mem += 2 # loss in fp16
+        # if data_type_l[0] == 'FP32':
+        #     l1_structs_mem += 2 # loss in fp32
+        # l1_structs_mem += 16 # vect_sum_args
+        # print(f"Size of structures in L1 (Double Buffer Mode): {l1_structs_mem} bytes")
+        # total_memory_occupation_bytes += l1_buff_size + l1_structs_mem
+
+        pass
 
     if total_memory_occupation_bytes > avail_mem_bytes:
         print("[DNN_Size_Checker]: DNN overflows PULP L1 memory!!\nExpected occupation: {} bytes vs {} available L1 ({}%)!".format(total_memory_occupation_bytes, avail_mem_bytes, (total_memory_occupation_bytes/avail_mem_bytes)*100))
@@ -148,11 +154,7 @@ def DNN_Size_Checker (layers_l, in_ch_l, out_ch_l, hk_l, wk_l, hin_l, win_l, h_s
 
     if USE_DMA in ['SB', 'DB']:
         print(f"Total L2 memory occupation: {l2_occupation} bytes")
-        if data_type_l[0] == 'FP32':
-            MAX_LAYER_DIM = MAX_LAYER_DIM/4
-        else:
-            MAX_LAYER_DIM = MAX_LAYER_DIM/2
-        MAX_LAYER_DIM = int(MAX_LAYER_DIM)
+        MAX_LAYER_DIM = int(MAX_LAYER_DIM / MAX_LAYER_DIM_BYTES)
 
     return total_memory_occupation_bytes
 
@@ -244,12 +246,15 @@ def DNN_Composer (proj_folder_path, project_name,
                     PROFILE_SINGLE_LAYERS, SEPARATE_BACKWARD_STEPS, CONV2D_USE_IM2COL, PRINT_TRAIN_LOSS)
         
     elif USE_DMA == 'DB':
-        utilsDB.GenerateNet(proj_folder_path, project_name,
-                    layers_l, in_ch_l, out_ch_l, hk_l, wk_l, hin_l, win_l,
-                    h_str_l, w_str_l, h_pad_l, w_pad_l,
-                    epochs, batch_size, learning_rate, optimizer, loss_fn,
-                    data_type_l, update_layer_l, sumnode_connections, MAX_LAYER_DIM,
-                    PROFILE_SINGLE_LAYERS, SEPARATE_BACKWARD_STEPS, CONV2D_USE_IM2COL, PRINT_TRAIN_LOSS)
+        print("[NOT_IMPLEMENTED_ERROR] Double Buffering not available, under revision!")
+        exit()
+        # utilsDB.GenerateNet(proj_folder_path, project_name,
+        #             layers_l, in_ch_l, out_ch_l, hk_l, wk_l, hin_l, win_l,
+        #             h_str_l, w_str_l, h_pad_l, w_pad_l,
+        #             epochs, batch_size, learning_rate, optimizer, loss_fn,
+        #             data_type_l, update_layer_l, sumnode_connections, MAX_LAYER_DIM,
+        #             PROFILE_SINGLE_LAYERS, SEPARATE_BACKWARD_STEPS, CONV2D_USE_IM2COL, PRINT_TRAIN_LOSS)
+
     else:
         print(f"[DNN_Composer]: Not supported argument for USE_DMA: '{USE_DMA}' given")
 

--- a/tools/TrainLib_Deployer/deployer_utils/deployment_utils.py
+++ b/tools/TrainLib_Deployer/deployer_utils/deployment_utils.py
@@ -546,6 +546,7 @@ def GenerateGM(proj_folder_path, project_name,
         #Skipconn
         elif sumnode_connections[layer] != -1 and layers_l[layer] != 'Sumnode':
             f.write(f"\n\t\t{variable} = self.l{layer}(x)")
+            f.write(f"\n\t\tx = {variable}")
         elif layers_l[layer] == "Sumnode": 
             f.write(f"\n\t\tx = y{layer} + x\t# Sumnode") 
         # Last layer

--- a/tools/TrainLib_Deployer/deployer_utils/deployment_utils_single_buffer.py
+++ b/tools/TrainLib_Deployer/deployer_utils/deployment_utils_single_buffer.py
@@ -560,7 +560,7 @@ def GenerateNet(proj_folder_path, project_name,
             num_bytes = 4
             if data_type_l[layer] == 'FP16':
                 num_bytes = 2
-            temp_size = 3 * in_ch_l[layer] * num_bytes
+            temp_size = in_ch_l[layer] * num_bytes # 3 * in_ch_l[layer] * num_bytes
             if max_size < temp_size:
                 max_size = temp_size
                 max_num_bytes = num_bytes
@@ -963,7 +963,7 @@ def GenerateNet(proj_folder_path, project_name,
             f.write("  #endif\n")  
 
         if layer > 0:
-            f.write("\treset_dim();\n")
+            f.write("\n\treset_dim();\n")
             f.write(f"\tload_input(&layer{layer}_in, 1);\n")
 
         if layers_l[layer] not in ['Skipnode', 'ReLU']:
@@ -1007,7 +1007,7 @@ def GenerateNet(proj_folder_path, project_name,
             print("[deployment_utils.GenerateNet]: PULP layer not implemented or wrapped in DNN Deployer!")
             exit()
         if layers_l[layer] != 'Skipnode':
-            f.write(f"\tstore_output(&layer{layer}_out, 1);\n\n")
+            f.write(f"\tstore_output(&layer{layer}_out, 1);\n")
             if layers_l[layer] == 'InstNorm':
                 num_bytes_load = 4
                 if data_type_l[layer] == 'FP16':
@@ -1170,7 +1170,7 @@ def GenerateNet(proj_folder_path, project_name,
             #f.write(ntemp.residualconn_template_copy_BW(lay, data_type_l[lay]))
             f.write(f"\tstore_output(&layer{lay}_in, 0);\n")
         elif layers_l[lay]  == 'InstNorm':
-            f.write(ntemp.InstNorm_template_BW(lay, data_type_l[lay]))
+            f.write(ntemp.InstNorm_template_BW(lay, data_type_l[lay], SEPARATE_BACKWARD_STEPS, FIRST_LAYER, update_layer_l[layer]))
         else:
             print("[deployment_utils.GenerateNet]: PULP layer not implemented or wrapped in DNN Deployer!")
             exit()

--- a/tools/TrainLib_Deployer/deployer_utils/net_templates.py
+++ b/tools/TrainLib_Deployer/deployer_utils/net_templates.py
@@ -525,6 +525,10 @@ def InstNorm_config_template(layer_number, skip_in_grad, update_layer):
     template  = "  l"+str(layer_number)+"_args.input = &layer"+str(layer_number)+"_in;\n"
     template += "  l"+str(layer_number)+"_args.coeff = &layer"+str(layer_number)+"_wgt;\n"
     template += "  l"+str(layer_number)+"_args.output = &layer"+str(layer_number)+"_out;\n"
+    template += "  l"+str(layer_number)+"_args.running_mean = l"+str(layer_number)+"_running_mean;\n"
+    template += "  l"+str(layer_number)+"_args.running_var = l"+str(layer_number)+"_running_var;\n"
+    template += "  l"+str(layer_number)+"_args.running_stdev = l"+str(layer_number)+"_running_stdev;\n"
+    template += "  l"+str(layer_number)+"_args.freeze_running_params = 0;\n"
     template += "  l"+str(layer_number)+"_args.skip_wg_grad = "+str(skip_wg_grad)+";\n"
     template += "  l"+str(layer_number)+"_args.skip_in_grad = "+str(skip_in_grad)+";\n"
     return template

--- a/tools/TrainLib_Deployer/deployer_utils/net_templates_single_buffer.py
+++ b/tools/TrainLib_Deployer/deployer_utils/net_templates_single_buffer.py
@@ -504,9 +504,17 @@ def sum(layer, data_type):
 
 
 
-def InstNorm_config_template(layer_number, skip_in_grad):
+def InstNorm_config_template(layer_number, skip_in_grad, update_layer):
+    skip_wg_grad = 0
+    if update_layer == 0:
+        skip_wg_grad = 1
     template  = "  l"+str(layer_number)+"_args.input = &input_blob;\n"
     template += "  l"+str(layer_number)+"_args.coeff = &weight_blob;\n"
     template += "  l"+str(layer_number)+"_args.output = &output_blob;\n"
+    template += "  l"+str(layer_number)+"_args.running_mean = running_mean_buffer;\n"
+    template += "  l"+str(layer_number)+"_args.running_var = running_var_buffer;\n"
+    template += "  l"+str(layer_number)+"_args.running_stdev = running_stdev_buffer;\n"
+    template += "  l"+str(layer_number)+"_args.freeze_running_params = 0;\n"
+    template += "  l"+str(layer_number)+"_args.skip_wg_grad = "+str(skip_wg_grad)+";\n"
     template += "  l"+str(layer_number)+"_args.skip_in_grad = "+str(skip_in_grad)+";\n"
     return template

--- a/tools/TrainLib_Deployer/deployer_utils/net_templates_single_buffer.py
+++ b/tools/TrainLib_Deployer/deployer_utils/net_templates_single_buffer.py
@@ -280,22 +280,33 @@ NORM TEMPLATES
 '''
 def InstNorm_template_FW(layer_number, data_type):
     if data_type == 'FP32':
-        template = "\tpulp_instnorm_fp32_fw_cl(&InstNorm_args);\n"
+        template = "\tpulp_instnorm_fp32_fw_cl(&l"+str(layer_number)+"_args);\n"
     elif data_type == 'FP16':
-        template = "\tpulp_instnorm_fp16_fw_cl(&InstNorm_args);\n"
+        template = "\tpulp_instnorm_fp16_fw_cl(&l"+str(layer_number)+"_args);\n"
     else:
         print("[net_templates.InstNorm_template_FW]: Invalid data type!")
         exit()  
     return template
 
-def InstNorm_template_BW(layer_number, data_type):
-    if data_type == 'FP32':
-        template = "\tpulp_instnorm_fp32_bw_cl(&InstNorm_args);\n"
-    elif data_type == 'FP16':
-        template = "\tpulp_instnorm_fp16_bw_cl(&InstNorm_args);\n"
+def InstNorm_template_BW(layer_number, data_type, SEPARATE_BACKWARD_STEPS, FIRST_LAYER, UPDATE_LAYER):
+    template = ""
+    if SEPARATE_BACKWARD_STEPS == 1:
+        if data_type == 'FP32':
+            if UPDATE_LAYER == 1:
+                template = "  pulp_instnorm_fp32_bw_param_grads_cl(&l"+str(layer_number)+"_args);\n"
+            if FIRST_LAYER == True:
+                template = "  pulp_instnorm_fp32_bw_input_grads_cl(&l"+str(layer_number)+"_args);\n"
+        elif data_type == 'FP16':
+            if UPDATE_LAYER == 1:
+                template = "  pulp_instnorm_fp16_bw_param_grads_cl(&l"+str(layer_number)+"_args);\n"
+            if FIRST_LAYER == False:
+                template = "  pulp_instnorm_fp16_bw_input_grads_cl(&l"+str(layer_number)+"_args);\n"
     else:
-        print("[net_templates.InstNorm_template_BW]: Invalid data type!")
-        exit()  
+        if not (FIRST_LAYER == True and UPDATE_LAYER == 0):
+            if data_type == 'FP32':
+                template = "  pulp_instnorm_fp32_bw_cl(&l"+str(layer_number)+"_args);\n"
+            elif data_type == 'FP16':
+                template = "  pulp_instnorm_fp16_bw_cl(&l"+str(layer_number)+"_args);\n"
     return template
 
 


### PR DESCRIPTION
This PR contains the following, in brief:

- Bug fixes to InstanceNorm's Backward steps + refactoring of its parameter allocation
- Refactoring of the memory computation in TrainLib_Deployer to account for non-allocated tensors during the backpropagation
- Fix and refactoring of the memory allocation on-device while using Single Buffer mode for layer-wise training computation
- Disabled Double Buffer mode (layer-wise), as it is affected by several bugs, and doesn't produce high performance gain with respect to Single Buffer mode
- Other minor bug fixes